### PR TITLE
#24: fixed trying to schedule event for null nextMeeting

### DIFF
--- a/source/bot.js
+++ b/source/bot.js
@@ -80,8 +80,10 @@ client.on("ready", () => {
 
 		// Begin checking for club reminders
 		for (let club of Object.values(getClubDictionary())) {
-			setClubReminder(club, channelManager);
-			scheduleClubEvent(club, guild);
+			if (club.timeslot.nextMeeting) {
+				setClubReminder(club, channelManager);
+				scheduleClubEvent(club, guild);
+			}
 		}
 
 		// Update pinned lists

--- a/source/commands/delete.js
+++ b/source/commands/delete.js
@@ -1,6 +1,7 @@
 const { Interaction } = require('discord.js');
 const Command = require('../classes/Command.js');
-const { isModerator, getManagedChannels } = require('../helpers.js');
+const { getManagedChannels } = require('../engines/channelEngine.js');
+const { isModerator } = require('../helpers.js');
 
 const options = [{ type: "Integer", name: "delay", description: "Number of hours to delay deleting the channel", required: true, choices: [] }];
 const subcomands = [];

--- a/source/commands/leave.js
+++ b/source/commands/leave.js
@@ -1,7 +1,8 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
 const Command = require('../classes/Command.js');
 const { SAFE_DELIMITER } = require('../constants.js');
-const { getManagedChannels, updateList, updateClub, getClubDictionary } = require('../helpers.js');
+const { getManagedChannels } = require('../engines/channelEngine.js');
+const { updateList, updateClub, getClubDictionary } = require('../helpers.js');
 
 const options = [];
 const subcomands = [];

--- a/source/engines/channelEngine.js
+++ b/source/engines/channelEngine.js
@@ -1,0 +1,6 @@
+/** Get the array of all club and topic text channel ids
+ * @returns {string[]}
+ */
+exports.getManagedChannels = function () {
+	return exports.getTopicIds().concat(Object.keys(exports.getClubDictionary()));
+}

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const { Collection, EmbedBuilder, MessageSelectMenu, TextChannel, ChannelManager, GuildChannelManager, Message, MessageOptions, Guild, ChannelType, PermissionsBitField, ActionRowBuilder, ButtonBuilder, MessagePayload } = require('discord.js');
+const { Collection, EmbedBuilder, MessageSelectMenu, TextChannel, ChannelManager, GuildChannelManager, Message, MessageOptions, Guild, ChannelType, PermissionsBitField, ActionRowBuilder, ButtonBuilder } = require('discord.js');
 const { Club, ClubTimeslot } = require('./classes/Club');
 const { MAX_SIGNED_INT } = require('./constants');
 const { randomEmbedFooter, embedTemplateBuilder } = require('./engines/messageEngine');
@@ -195,13 +195,6 @@ exports.reminderTimeouts = {};
 exports.eventTimeouts = {};
 
 // Functions
-/** Get the array of all club and topic text channel ids
- * @returns {string[]}
- */
-exports.getManagedChannels = function () {
-	return exports.getTopicIds().concat(Object.keys(exports.getClubDictionary()));
-}
-
 /** Update the club or topics list message
  * @param {GuildChannelManager} channelManager
  * @param {"topics" | "clubs"} listType
@@ -741,7 +734,7 @@ exports.cancelClubEvent = function (voiceChannelId, eventId, eventManager) {
  */
 exports.setClubReminder = async function (club, channelManager) {
 	if (club.timeslot.nextMeeting) {
-		let timeout = setTimeout(
+		const timeout = setTimeout(
 			reminderWaitLoop,
 			calculateReminderMS(club.timeslot.nextMeeting),
 			club,
@@ -768,22 +761,8 @@ function reminderWaitLoop(club, channelManager) {
 	if (club.timeslot.nextMeeting) {
 		if (calculateReminderMS(club.timeslot.nextMeeting) < MAX_SIGNED_INT) {
 			channelManager.fetch(club.id).then(async textChannel => {
-				const components = [];
-				let invite;
-				if (club.timeslot.eventId) {
-					invite = await (await channelManager.guild.scheduledEvents.fetch(club.timeslot.eventId)).channel.createInvite();
-				}
-				if (invite?.url) {
-					components.push(new ActionRowBuilder().addComponents(
-						new ButtonBuilder()
-							.setLabel("Join Voice")
-							.setStyle("LINK")
-							.setURL(invite.url)
-					))
-				}
 				textChannel.send({
-					content: `@everyone ${club.timeslot.message ? club.timeslot.message : `Reminder: This club about this time tomorrow (<t:${club.timeslot.nextMeeting}:t>)!`}`,
-					components
+					content: `@everyone ${club.timeslot.message ? club.timeslot.message : `Reminder: This club about this time tomorrow (<t:${club.timeslot.nextMeeting}:t>)! <#${club.voiceChannelId}>`}`,
 				});
 			});
 			if (club.timeslot.periodCount) {


### PR DESCRIPTION
Summary
-------
- fixed trying to schedule event for null nextMeeting
- replace reminder Join button with voice channel mention
- move getManagedChannels() into channelEngine

Local Tests Performed
---------------------
- bot startup with null nextMeeting (real cause) and past nextMeeting (presumed cause)
- verify mention is in reminder
- bot compile

Issue
-----
Closes #24