### PR TITLE
#57: Club event reminders schedule for the current meeting, not the next meeting

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,6 @@
 # HorizonsBot Change Log
+#### HorizonsBot Version 2.0.2:
+- Fixed club events being scheduled for the current meeting instead of the next meeting
 #### HorizonsBot Version 2.0.1:
 - Clubs that aren't recruiting are filtered out of the club list select
 - Fixed selects (drop downs) crashing the bot

--- a/source/bot.js
+++ b/source/bot.js
@@ -83,9 +83,9 @@ client.on("ready", () => {
 		for (const club of Object.values(getClubDictionary())) {
 			const isNextMeetingInFuture = Date.now() < club.timeslot.nextMeeting * 1000;
 			if (isNextMeetingInFuture) {
-				setClubReminder(club, channelManager);
+				setClubReminder(club.id, club.timeslot.nextMeeting, channelManager);
 				if (club.isRecruiting() && club.timeslot.periodCount) {
-					scheduleClubEvent(club, guild);
+					scheduleClubEvent(club.id, club.voiceChannelId, club.timeslot.nextMeeting, guild);
 				}
 			} else {
 				club.timeslot.setNextMeeting(null);

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -590,25 +590,43 @@ exports.createClubEvent = function (club, guild) {
 	}
 }
 
+/** The number of ms until the timestamp, but not more than the max allowable setTimeout duration
+ * @param {number} timestamp units: seconds
+ */
+function clampedTimestampToMS(timestamp) {
+	return Math.min((timestamp * 1000) - Date.now(), MAX_SET_TIMEOUT);
+}
+
+/** Checks if the given unix timestamp can be scheduled to with 1 setTimeout
+ * @param {number} timestamp units: seconds
+ */
+function isTimestampWithinOneTimeout(timestamp) {
+	return (timestamp * 1000) - Date.now() <= MAX_SET_TIMEOUT;
+}
+
 /** Create a timeout to create a scheduled event for a club after the current event passes
- * @param {Club} club
+ * @param {string} club
+ * @param {string} clubVoiceId
+ * @param {number | null} nextMeetingTimestamp
  * @param {Guild} guild
  */
-exports.scheduleClubEvent = function (club, guild) {
-	const msToNextMeeting = (club.timeslot.nextMeeting * 1000) - Date.now();
-	if (msToNextMeeting <= MAX_SET_TIMEOUT) {
-		let timeout = setTimeout((clubId, timeoutGuild) => {
-			const club = exports.getClubDictionary()[clubId];
+exports.scheduleClubEvent = function (clubId, clubVoiceId, nextMeetingTimestamp, guild) {
+	if (isTimestampWithinOneTimeout(nextMeetingTimestamp)) {
+		const timeout = setTimeout((timeoutClubId, timeoutGuild) => {
+			const club = exports.getClubDictionary()[timeoutClubId];
 			if (club?.isRecruiting()) {
 				exports.createClubEvent(club, timeoutGuild);
 			}
-		}, msToNextMeeting, club.id, guild);
-		exports.eventTimeouts[club.voiceChannelId] = timeout;
+		}, clampedTimestampToMS(nextMeetingTimestamp), clubId, guild);
+		exports.eventTimeouts[clubVoiceId] = timeout;
 	} else {
-		const timeout = setTimeout((timeoutClub, timeoutGuild) => {
-			exports.scheduleClubEvent(timeoutClub, timeoutGuild);
-		}, MAX_SET_TIMEOUT, club, guild);
-		exports.eventTimeouts[club.voiceChannelId] = timeout;
+		const timeout = setTimeout((timeoutClubId, timeoutGuild) => {
+			const club = exports.getClubDictionary()[timeoutClubId];
+			if (club) {
+				exports.scheduleClubEvent(club.id, club.voiceChannelId, club.timeslot.nextMeeting, timeoutGuild);
+			}
+		}, MAX_SET_TIMEOUT, clubId, guild);
+		exports.eventTimeouts[clubVoiceId] = timeout;
 	}
 }
 
@@ -628,50 +646,39 @@ exports.cancelClubEvent = function (club, eventManager) {
 }
 
 /** Set a timeout to send a reminder message to the given club a day before its next meeting
- * @param {Club} club
+ * @param {string} clubId
+ * @param {number | null} nextMeetingTimestamp
  * @param {ChannelManager} channelManager
  */
-exports.setClubReminder = async function (club, channelManager) {
-	if (club.timeslot.nextMeeting) {
+exports.setClubReminder = async function (clubId, nextMeetingTimestamp, channelManager) {
+	if (nextMeetingTimestamp) {
 		const timeout = setTimeout(
-			reminderWaitLoop,
-			calculateReminderMS(club.timeslot.nextMeeting),
-			club,
+			async (clubId, channelManager) => {
+				const club = exports.getClubDictionary()[clubId];
+				if (club.timeslot.nextMeeting) {
+					if (isTimestampWithinOneTimeout(club.timeslot.nextMeeting - exports.timeConversion(1, "d", "s"))) {
+						if (club.timeslot.periodCount) {
+							await exports.sendClubReminder(club, channelManager);
+							const timeGap = exports.timeConversion(club.timeslot.periodCount, club.timeslot.periodUnits === "weeks" ? "w" : "d", "s");
+							club.timeslot.setNextMeeting(club.timeslot.nextMeeting + timeGap);
+							exports.updateClub(club);
+							exports.scheduleClubEvent(club.id, club.voiceChannelId, club.timeslot.nextMeeting, channelManager.guild);
+							exports.setClubReminder(club.id, club.timeslot.nextMeeting, channelManager);
+						} else {
+							club.timeslot.setEventId(null);
+							exports.updateList(channelManager, "clubs");
+							exports.updateClub(club, channelManager);
+						}
+					} else {
+						exports.setClubReminder(club.id, club.timeslot.nextMeeting, channelManager);
+					}
+				}
+			},
+			clampedTimestampToMS(nextMeetingTimestamp - exports.timeConversion(1, "d", "s")),
+			clubId,
 			channelManager);
-		exports.reminderTimeouts[club.id] = timeout;
+		exports.reminderTimeouts[clubId] = timeout;
 		exports.updateList(channelManager, "clubs");
-	}
-}
-
-/** The number of ms until a day before the next meeting, but not more than the max allowable setTimeout duration
- * @param {number} timestamp The unix timestamp of the next meeting (in seconds)
- */
-function calculateReminderMS(timestamp) {
-	return Math.min((timestamp * 1000) - exports.timeConversion(1, "d", "ms") - Date.now(), MAX_SET_TIMEOUT);
-}
-
-/** If the club reminder would be set for further than the a max signed int ms in the future (max allowable setTimeout duration), try to set the club reminder again later
- * @param {Club} club
- * @param {ChannelManager} channelManager
- */
-async function reminderWaitLoop(club, channelManager) {
-	if (club.timeslot.nextMeeting) {
-		if (calculateReminderMS(club.timeslot.nextMeeting) < MAX_SET_TIMEOUT) {
-			if (club.timeslot.periodCount) {
-				await exports.sendClubReminder(club, channelManager);
-				const timeGap = exports.timeConversion(club.timeslot.periodCount, club.timeslot.periodUnits === "weeks" ? "w" : "d", "s");
-				club.timeslot.setNextMeeting(club.timeslot.nextMeeting + timeGap);
-				exports.updateClub(club);
-				exports.scheduleClubEvent(club, channelManager.guild);
-				exports.setClubReminder(club, channelManager);
-			} else {
-				club.timeslot.setEventId(null);
-				exports.updateList(channelManager, "clubs");
-				exports.updateClub(club, channelManager);
-			}
-		} else {
-			exports.setClubReminder(club, channelManager);
-		}
 	}
 }
 

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -640,7 +640,6 @@ exports.setClubReminder = async function (club, channelManager) {
 			channelManager);
 		exports.reminderTimeouts[club.id] = timeout;
 		exports.updateList(channelManager, "clubs");
-		exports.updateClub(club);
 	}
 }
 
@@ -662,6 +661,7 @@ async function reminderWaitLoop(club, channelManager) {
 				await exports.sendClubReminder(club, channelManager);
 				const timeGap = exports.timeConversion(club.timeslot.periodCount, club.timeslot.periodUnits === "weeks" ? "w" : "d", "s");
 				club.timeslot.setNextMeeting(club.timeslot.nextMeeting + timeGap);
+				exports.updateClub(club);
 				exports.scheduleClubEvent(club, channelManager.guild);
 				exports.setClubReminder(club, channelManager);
 			} else {

--- a/source/modalSubmissions/changeclubmeeting.js
+++ b/source/modalSubmissions/changeclubmeeting.js
@@ -34,9 +34,9 @@ module.exports = new ModalSubmission(id,
 
 					await createClubEvent(club, interaction.guild);
 					if (club.isRecruiting() && club.timeslot.periodCount) {
-						scheduleClubEvent(club, interaction.guild);
+						scheduleClubEvent(club.id, club.voiceChannelId, club.timeslot.nextMeeting, interaction.guild);
 					}
-					setClubReminder(club, interaction.guild.channels);
+					setClubReminder(club.id, club.timeslot.nextMeeting, interaction.guild.channels);
 				}
 			}
 


### PR DESCRIPTION
Summary
-------
Because the `scheduleClubEvent` fetches the club from the dictionary (to catch changes between scheduling and resolution), I suspect the `nextMeeting` increment is not being saved before the `scheduleClubEvent` is resolving on prod (was not able to reproduce locally). I've moved `updateClub` before `scheduleClubEvent` and updated the interface of `scheduleClubEvent` and `setClubReminder` to avoid implying the provided club includes value data to be resolved.

Local Tests Performed
---------------------
Was not able to reproduce locally. Check for regression on setting a club's next meeting.

Issue
-----
Closes #57