### PR TITLE
#64: fixed Start Event button starting wrong event

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,8 @@
 # HorizonsBot Change Log
+#### HorizonsBot Version 2.1.0:
+- Fixed a bug where setting club meeting interval wasn't saving the units
+- Fixed a bug where club reminder start event buttons were starting the wrong event
+- Fixed a bug where club events wouldn't get updated after changing club settings
 #### HorizonsBot Version 2.0.2:
 - Fixed club events being scheduled for the current meeting instead of the next meeting
 #### HorizonsBot Version 2.0.1:

--- a/source/bot.js
+++ b/source/bot.js
@@ -9,7 +9,7 @@ const { callSelect } = require("./selects/_selectDictionary.js");
 const { getTopicIds, addTopic, removeTopic } = require("./engines/channelEngine.js");
 const { versionEmbedBuilder } = require("./engines/messageEngine.js");
 const { isClubHostOrModerator, isModerator } = require("./engines/permissionEngine.js");
-const { listMessages, pinClubList, getClubDictionary, updateList, getPetitions, setPetitions, checkPetition, removeClub, scheduleClubEvent, setClubReminder } = require("./helpers.js");
+const { listMessages, pinClubList, getClubDictionary, updateList, getPetitions, setPetitions, checkPetition, removeClub, scheduleClubReminderAndEvent } = require("./helpers.js");
 const { SAFE_DELIMITER, guildId } = require('./constants.js');
 const versionData = require('../config/_versionData.json');
 //#endregion
@@ -83,10 +83,7 @@ client.on("ready", () => {
 		for (const club of Object.values(getClubDictionary())) {
 			const isNextMeetingInFuture = Date.now() < club.timeslot.nextMeeting * 1000;
 			if (isNextMeetingInFuture) {
-				setClubReminder(club.id, club.timeslot.nextMeeting, channelManager);
-				if (club.isRecruiting() && club.timeslot.periodCount) {
-					scheduleClubEvent(club.id, club.voiceChannelId, club.timeslot.nextMeeting, guild);
-				}
+				scheduleClubReminderAndEvent(club.id, club.timeslot.nextMeeting, channelManager);
 			} else {
 				club.timeslot.setNextMeeting(null);
 				club.timeslot.setEventId(null);

--- a/source/buttons/startevent.js
+++ b/source/buttons/startevent.js
@@ -9,8 +9,8 @@ module.exports = new Button(id,
 	 * @param {import('discord.js').Interaction} interaction
 	 * @param {Array<string>} args
 	 */
-	(interaction, []) => {
-		const { hostId, timeslot: { eventId } } = getClubDictionary()[interaction.message.channel.id];
+	(interaction, [eventId]) => {
+		const { hostId } = getClubDictionary()[interaction.message.channel.id];
 		if (!isModerator(interaction.member) && interaction.user.id !== hostId) {
 			return interaction.reply({ content: "Only the club's host or a moderator can start the event.", ephemeral: true });
 		}

--- a/source/commands/club-send-reminder.js
+++ b/source/commands/club-send-reminder.js
@@ -14,6 +14,6 @@ module.exports.execute = (interaction) => {
 		return interaction.reply({ content: 'This club does not have a time set for its next meeting.', ephemeral: true });
 	}
 
-	sendClubReminder(club, interaction.guild.channels);
+	sendClubReminder(club.id, interaction.guild.channels);
 	interaction.reply({ content: "Club reminder sent!", ephemeral: true });
 }

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -648,7 +648,7 @@ exports.sendClubReminder = async (clubId, channelManager) => {
 	// NOTE: defaultReminder.length (without interpolated length) must be less than or equal to 55 characters so it fits in the config modal placeholder with its wrapper (100 characters)
 	const defaultReminder = `Reminder: This club will meet at <t:${club.timeslot.nextMeeting}> in <#${club.voiceChannelId}>!`;
 	const reminderPayload = {
-		content: `${club.timeslot.eventId} ${club.timeslot.message ? club.timeslot.message : defaultReminder}`, //TODONOW revert from test settings
+		content: `@everyone ${club.timeslot.message ? club.timeslot.message : defaultReminder}`,
 	};
 	if (club.timeslot.eventId) {
 		const event = await channelManager.guild.scheduledEvents.fetch(club.timeslot.eventId).catch(console.error);

--- a/source/modalSubmissions/changeclubmeeting.js
+++ b/source/modalSubmissions/changeclubmeeting.js
@@ -1,15 +1,14 @@
-const { Interaction } = require('discord.js');
 const ModalSubmission = require('../classes/ModalSubmission.js');
 const { clubEmbedBuilder } = require('../engines/messageEngine.js');
-const { getClubDictionary, updateClub, updateClubDetails, updateList, clearClubReminder, cancelClubEvent, setClubReminder, createClubEvent, scheduleClubEvent } = require('../helpers.js');
+const { getClubDictionary, updateClub, updateClubDetails, updateList, clearClubReminder, cancelClubEvent, scheduleClubReminderAndEvent, createClubEvent } = require('../helpers.js');
 
 const YEAR_IN_MS = 31556926000;
 
 const id = "changeclubmeeting";
 module.exports = new ModalSubmission(id,
 	/** Set the meeting time/repetition properties for the club with provided id
-	 * @param {Interaction} interaction
-	 * @param {Array<string>} args
+	 * @param {import('discord.js').Interaction} interaction
+	 * @param {string[]} args
 	 */
 	async (interaction, [clubId]) => {
 		const club = getClubDictionary()[clubId];
@@ -29,14 +28,6 @@ module.exports = new ModalSubmission(id,
 					errors.nextMeeting = "Discord does not allow the creation of events 5 years in the future. Please schedule your next meeting later.";
 				} else {
 					club.timeslot.setNextMeeting(nextMeetingInput);
-					clearClubReminder(club.id);
-					cancelClubEvent(club, interaction.guild.scheduledEvents);
-
-					await createClubEvent(club, interaction.guild);
-					if (club.isRecruiting() && club.timeslot.periodCount) {
-						scheduleClubEvent(club.id, club.voiceChannelId, club.timeslot.nextMeeting, interaction.guild);
-					}
-					setClubReminder(club.id, club.timeslot.nextMeeting, interaction.guild.channels);
 				}
 			}
 
@@ -66,6 +57,12 @@ module.exports = new ModalSubmission(id,
 				errors.periodUnits = `Input ${periodUnitsInput} did not match "days" or "weeks"`;
 			}
 		}
+
+		cancelClubEvent(club, interaction.guild.scheduledEvents);
+		createClubEvent(club, interaction.guild);
+		clearClubReminder(club.id);
+		scheduleClubReminderAndEvent(club.id, club.timeslot.nextMeeting, interaction.guild.channels);
+
 		updateClubDetails(club, interaction.channel);
 		updateList(interaction.guild.channels, "clubs");
 		updateClub(club);

--- a/source/modalSubmissions/changeclubmeeting.js
+++ b/source/modalSubmissions/changeclubmeeting.js
@@ -58,8 +58,8 @@ module.exports = new ModalSubmission(id,
 				errors.periodCount = `Could not interpret ${unparsedValue} as integer`;
 			}
 		}
-		if (fields.fields.has("periodUnits")) {
-			const periodUnitsInput = fields.getTextInputValue("periodUnits");
+		if (fields.fields.has("periodUnit")) {
+			const periodUnitsInput = fields.getTextInputValue("periodUnit");
 			if (["days", "weeks"].includes(periodUnitsInput)) {
 				club.timeslot.periodUnits = periodUnitsInput;
 			} else {


### PR DESCRIPTION
Summary
-------
- fixed Start Event button starting wrong event
- fixed /club-config not saving changes to meeting interval units
- fixed a bug where club description changes would lag a meeting behind for being updated

Local Tests Performed
---------------------
- [x] was able to change club meeting interval
- [x] verified club reminder start event buttons working correctly
   1. set the club to repeat each day
   2. set the next meeting for a minute in the future
   3. reminder would fire for next meeting immediately (within 1 day), and then fire for day after in a minute
   4. confirmed second reminder was associated with future event instead of current one
- [x] confirmed newly made club events had current instead of persisted club data

Issue
-----
Closes #24