### PR TITLE
#1: delete channel and message ids when reference messages are deleted or can't be found

### DIFF
--- a/source/bot.js
+++ b/source/bot.js
@@ -200,14 +200,4 @@ client.on(Events.ChannelDelete, ({ id, guild }) => {
 		}
 	}
 })
-
-client.on(Events.MessageDelete, ({ id: messageId }) => {
-	for (const messageType in referenceMessages) {
-		if (referenceMessages[messageType].messageId === messageId) {
-			referenceMessages[messageType].channelId = "";
-			referenceMessages[messageType].messageId = "";
-			saveObject(referenceMessages, "referenceMessageIds.json");
-		}
-	}
-})
 //#endregion

--- a/source/bot.js
+++ b/source/bot.js
@@ -10,6 +10,7 @@ const { scheduleClubReminderAndEvent } = require("./engines/clubEngine.js");
 const { versionEmbedBuilder } = require("./engines/messageEngine.js");
 const { isClubHostOrModerator, isModerator } = require("./engines/permissionEngine.js");
 const { referenceMessages, getClubDictionary, getPetitions, setPetitions, checkPetition, getTopicIds, addTopic, removeTopic, removeClub, updateList } = require("./engines/referenceEngine.js");
+const { saveObject } = require("./helpers.js");
 const { SAFE_DELIMITER, guildId } = require('./constants.js');
 const versionData = require('../config/_versionData.json');
 
@@ -104,7 +105,21 @@ client.on(Events.ClientReady, () => {
 			channelManager.fetch(referenceMessages.rules.channelId).then(channel => {
 				channel.messages.fetch(referenceMessages.rules.messageId).then(message => {
 					message.edit({ embeds: [rulesEmbed] });
+				}).catch(error => {
+					if (error.code === 10008) { // Unknown Message
+						referenceMessages.rules.channelId = "";
+						referenceMessages.rules.messageId = "";
+						saveObject(referenceMessages, "referenceMessageIds.json");
+					}
+					console.error(error);
 				})
+			}).catch(error => {
+				if (error.code === 10003) { // Unknown Channel
+					referenceMessages.rules.channelId = "";
+					referenceMessages.rules.messageId = "";
+					saveObject(referenceMessages, "referenceMessageIds.json");
+				}
+				console.error(error);
 			})
 		}
 	})
@@ -182,6 +197,16 @@ client.on(Events.ChannelDelete, ({ id, guild }) => {
 				}
 				return;
 			}
+		}
+	}
+})
+
+client.on(Events.MessageDelete, ({ id: messageId }) => {
+	for (const messageType in referenceMessages) {
+		if (referenceMessages[messageType].messageId === messageId) {
+			referenceMessages[messageType].channelId = "";
+			referenceMessages[messageType].messageId = "";
+			saveObject(referenceMessages, "referenceMessageIds.json");
 		}
 	}
 })


### PR DESCRIPTION
Summary
-------
- delete channel and message ids when reference messages are deleted or can't be found

Local Tests Performed
---------------------
- [x] bot still turns on
- [x] ids deleted when message is deleted
- [x] ids deleted when message not found during startup or updateList

Issue
-----
Closes #1