### PR TITLE
#?: club events use club images

### DIFF
--- a/source/bot.js
+++ b/source/bot.js
@@ -95,13 +95,13 @@ client.on(Events.ClientReady, () => {
 		}
 
 		// Update reference messages
-		if (referenceMessages.petition) {
+		if (referenceMessages.petition?.channelId && referenceMessages.petition?.messageId) {
 			updateList(channelManager, "petition");
 		}
-		if (referenceMessages.club) {
+		if (referenceMessages.club?.channelId && referenceMessages.club?.messageId) {
 			updateList(channelManager, "club");
 		}
-		if (referenceMessages.rules) {
+		if (referenceMessages.rules?.channelId && referenceMessages.rules?.messageId) {
 			channelManager.fetch(referenceMessages.rules.channelId).then(channel => {
 				channel.messages.fetch(referenceMessages.rules.messageId).then(message => {
 					message.edit({ embeds: [rulesEmbed] });


### PR DESCRIPTION
Summary
-------
- club events now use the club's image
- fixed startup reference updates failing to skip when reference ids were missing
- fixed some missing imports

Local Tests Performed
---------------------
- [x] bot still turns on
- [x] configured a test club to send an event with an image

Issue
-----
N/A