### PR TITLE
#43: added /at-event command

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@
 - Fixed slash commands being shown twice in the menu
 - Some slash commands can now be used in DMs
 - All bot interactions now have cooldowns (3s default)
+- Added `/at-event` which pings all users interested in a given event
 #### HorizonsBot Version 2.1.0:
 - Removed opt-in topics handling, please use the Channel & Roles Browser instead
    - Retained `/petition` for text channels

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@
 - Combined `/about`, `/data-policy`, `/press-kit`, `/roles`, & `/rules` into `/info`
 - Club events now use the club's image
 - Ported `/petition-veto`
+- Fixed slash commands being shown twice in the menu
+- Some slash commands can now be used in DMs
 #### HorizonsBot Version 2.1.0:
 - Removed opt-in topics handling, please use the Channel & Roles Browser instead
    - Retained `/petition` for text channels

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@
 - Ported `/petition-veto`
 - Fixed slash commands being shown twice in the menu
 - Some slash commands can now be used in DMs
+- All bot interactions now have cooldowns (3s default)
 #### HorizonsBot Version 2.1.0:
 - Removed opt-in topics handling, please use the Channel & Roles Browser instead
    - Retained `/petition` for text channels

--- a/config_template/_versionData.json
+++ b/config_template/_versionData.json
@@ -1,0 +1,1 @@
+{"patchNotesChannelId":"","lastPostedVersion":"0.0.0"}

--- a/source/buttons/_buttonDictionary.js
+++ b/source/buttons/_buttonDictionary.js
@@ -9,14 +9,12 @@ for (const file of [
 	"startevent.js"
 ]) {
 	const button = require(`./${file}`);
-	buttonDictionary[button.name] = button;
+	buttonDictionary[button.customId] = button;
 }
 
 /**
  * @param {string} mainId
- * @param {import("discord.js").Interaction} interaction
- * @param {string[]} args
  */
-exports.callButton = function (mainId, interaction, args) {
-	buttonDictionary[mainId].execute(interaction, args);
+exports.getButton = function (mainId) {
+	return buttonDictionary[mainId];
 }

--- a/source/buttons/changeclubinfo.js
+++ b/source/buttons/changeclubinfo.js
@@ -4,7 +4,7 @@ const { SAFE_DELIMITER } = require('../constants.js');
 const { getClubDictionary } = require('../engines/referenceEngine.js');
 
 const id = "changeclubinfo";
-module.exports = new Button(id,
+module.exports = new Button(id, 3000,
 	/** Opens a modal to change the name, description, game, imageURL, or color of the club */
 	(interaction, [clubId]) => {
 		const club = getClubDictionary()[clubId];

--- a/source/buttons/changeclubmeeting.js
+++ b/source/buttons/changeclubmeeting.js
@@ -4,7 +4,7 @@ const { SAFE_DELIMITER } = require('../constants.js');
 const { getClubDictionary } = require('../engines/referenceEngine.js');
 
 const id = "changeclubmeeting";
-module.exports = new Button(id,
+module.exports = new Button(id, 3000,
 	/** Opens a modal to change the meeting time/repetition the club */
 	(interaction, [clubId]) => {
 		const club = getClubDictionary()[clubId];

--- a/source/buttons/changeclubseats.js
+++ b/source/buttons/changeclubseats.js
@@ -4,7 +4,7 @@ const { SAFE_DELIMITER } = require('../constants.js');
 const { getClubDictionary } = require('../engines/referenceEngine.js');
 
 const id = "changeclubseats";
-module.exports = new Button(id,
+module.exports = new Button(id, 3000,
 	/** Opens a modal to change the max seats and recruiting toggle of the club */
 	(interaction, [clubId]) => {
 		const club = getClubDictionary()[clubId];

--- a/source/buttons/delete.js
+++ b/source/buttons/delete.js
@@ -1,7 +1,7 @@
 const { MessageFlags } = require('discord.js');
 const Button = require('../classes/Button.js');
 
-module.exports = new Button("delete",
+module.exports = new Button("delete", 3000,
 	/** Delete a club, the host left */
 	(interaction, [channelId]) => {
 		interaction.reply({ content: "This club is being deleted, its host has left.", flags: MessageFlags.SuppressNotifications }).then(() => {

--- a/source/buttons/join.js
+++ b/source/buttons/join.js
@@ -2,7 +2,7 @@ const Button = require('../classes/Button.js');
 const { guildId } = require('../constants.js');
 const { joinChannel } = require('../engines/clubEngine.js');
 
-module.exports = new Button("join",
+module.exports = new Button("join", 3000,
 	/** Join the club specified in args */
 	(interaction, [channelId]) => {
 		interaction.client.guilds.fetch(guildId).then(guild => {

--- a/source/buttons/startevent.js
+++ b/source/buttons/startevent.js
@@ -4,7 +4,7 @@ const { getClubDictionary } = require('../engines/referenceEngine.js');
 const { isModerator } = require("../engines/permissionEngine.js");
 
 const id = "startevent";
-module.exports = new Button(id,
+module.exports = new Button(id, 3000,
 	/** Start a club's event */
 	(interaction, [eventId]) => {
 		const { hostId } = getClubDictionary()[interaction.message.channel.id];

--- a/source/classes/Button.js
+++ b/source/classes/Button.js
@@ -2,11 +2,13 @@ const { Interaction } = require('discord.js');
 
 module.exports = class Button {
 	/** IHP wrapper for message buttons
-	 * @param {string} nameInput
+	 * @param {string} customIdInput
+	 * @param {number} cooldownInMS
 	 * @param {(interaction: Interaction, args: Array<string>) => void} executeFunction
 	 */
-	constructor(nameInput, executeFunction) {
-		this.name = nameInput;
+	constructor(customIdInput, cooldownInMS, executeFunction) {
+		this.customId = customIdInput;
+		this.cooldown = cooldownInMS;
 		this.execute = executeFunction;
 	}
 }

--- a/source/classes/Command.js
+++ b/source/classes/Command.js
@@ -2,14 +2,15 @@ const { SlashCommandBuilder } = require("discord.js");
 
 module.exports = class Command {
 	/** IHP wrapper for slash commands
-	 * @param {string} nameInput
+	 * @param {string} customIdInput
 	 * @param {string} descriptionInput
 	 * @param {"none" | "moderator" | "moderator/club host"} permissionLevelEnum
+	 * @param {number} cooldownInMS
 	 * @param {Array} optionsInput
 	 * @param {Array} subcommandsInput
 	 */
-	constructor(nameInput, descriptionInput, isDMCommand, permissionLevelEnum, optionsInput, subcommandsInput) {
-		this.name = nameInput;
+	constructor(customIdInput, descriptionInput, isDMCommand, permissionLevelEnum, cooldownInMS, optionsInput, subcommandsInput) {
+		this.customId = customIdInput;
 		switch (permissionLevelEnum) {
 			case "moderator":
 				this.description = `(moderator) ${descriptionInput}`;
@@ -21,8 +22,9 @@ module.exports = class Command {
 				this.description = descriptionInput;
 		}
 		this.permissionLevel = permissionLevelEnum;
+		this.cooldown = cooldownInMS;
 		this.data = new SlashCommandBuilder()
-			.setName(nameInput)
+			.setName(customIdInput)
 			.setDescription(this.description)
 			.setDMPermission(isDMCommand);
 		optionsInput.forEach(option => {

--- a/source/classes/ModalSubmission.js
+++ b/source/classes/ModalSubmission.js
@@ -2,11 +2,13 @@ const { Interaction } = require('discord.js');
 
 module.exports = class ModalSubmission {
 	/** IHP wrapper for modal submissions
-	 * @param {string} nameInput
+	 * @param {string} customIdInput
+	 * @param {number} cooldownInMS
 	 * @param {(interaction: Interaction, args: Array<string>) => void} executeFunction
 	 */
-	constructor(nameInput, executeFunction) {
-		this.name = nameInput;
+	constructor(customIdInput, cooldownInMS, executeFunction) {
+		this.customId = customIdInput;
+		this.cooldown = cooldownInMS;
 		this.execute = executeFunction;
 	}
 }

--- a/source/classes/Select.js
+++ b/source/classes/Select.js
@@ -2,11 +2,13 @@ const { Interaction } = require('discord.js');
 
 module.exports = class Select {
 	/** IHP wrapper for select menus (drop downs)
-	 * @param {string} nameInput
+	 * @param {string} customIdInput
+	 * @param {number} cooldownInMS
 	 * @param {(interaction: Interaction, args: Array<string>) => void} executeFunction
 	 */
-	constructor(nameInput, executeFunction) {
-		this.name = nameInput;
+	constructor(customIdInput, cooldownInMS, executeFunction) {
+		this.customId = customIdInput;
+		this.cooldown = cooldownInMS;
 		this.execute = executeFunction;
 	}
 }

--- a/source/commands/_commandDictionary.js
+++ b/source/commands/_commandDictionary.js
@@ -19,7 +19,7 @@ exports.slashData = [];
 
 for (const file of exports.commandFiles) {
 	const command = require(`./${file}`);
-	commandDictionary[command.name] = command;
+	commandDictionary[command.customId] = command;
 	exports.slashData.push(command.data.toJSON());
 }
 

--- a/source/commands/_commandDictionary.js
+++ b/source/commands/_commandDictionary.js
@@ -4,7 +4,7 @@ const CommandSet = require('../classes/CommandSet.js');
 // A maximum of 25 command sets are supported by /commands to conform with MessageEmbed limit of 25 fields
 exports.commandSets = [
 	new CommandSet("General Commands", "These commands are general use utilities for the server.", false,
-		["at-channel.js", "timestamp.js", "roll.js", "petition.js"]),
+		["at-channel.js", "timestamp.js", "roll.js", "petition.js", "at-event.js"]),
 	new CommandSet("Informantional Commands", "Use these commands to learn more about this server or HorizonsBot.", false,
 		["info.js", "commands.js", "list.js", "version.js", "petition-check.js"]),
 	new CommandSet("Club Commands", "Clubs are private text and voice channels that include organization utilities like automatic reminders.", false,

--- a/source/commands/_command_blueprint.js
+++ b/source/commands/_command_blueprint.js
@@ -25,7 +25,7 @@ const subcommands = [
 		]
 	}
 ];
-module.exports = new Command(customId, "description", false, "none", options, subcommands);
+module.exports = new Command(customId, "description", false, "none", 3000, options, subcommands);
 
 /** Command specifications go here
  * @param {import('discord.js').Interaction} interaction

--- a/source/commands/at-channel.js
+++ b/source/commands/at-channel.js
@@ -1,30 +1,19 @@
 const Command = require('../classes/Command.js');
 const { noAts } = require('../engines/permissionEngine.js');
-const { timeConversion } = require('../helpers.js');
-
-const atIds = new Set(); // contains userIds
 
 const options = [
 	{ type: "String", name: "message", description: "The text of the notification", required: true, choices: [] },
 	{ type: "String", name: "type", description: "Who to notify", required: false, choices: [{ name: "Only online users in this channel", value: "@here" }, { name: "All users in this channel", value: "@everyone" }] }
 ];
 const subcomands = [];
-module.exports = new Command("at-channel", "Send a ping to the current channel", false, "none", options, subcomands);
+module.exports = new Command("at-channel", "Send a ping to the current channel", false, "none", 300000, options, subcomands);
 
 /** Send a rate-limited ping
  * @param {import('discord.js').Interaction} interaction
  */
 module.exports.execute = (interaction) => {
 	if (!noAts.includes(interaction.user.id)) {
-		if (!atIds.has(interaction.user.id)) {
-			atIds.add(interaction.user.id);
-			setTimeout((timeoutId) => {
-				atIds.delete(timeoutId);
-			}, timeConversion(5, "m", "ms"), interaction.user.id);
-			interaction.reply(`${interaction.options.getString("type") === "@everyone" ? "@everyone" : "@here"} ${interaction.options.getString("message")}`);
-		} else {
-			interaction.reply({ content: "You may only use `/at-channel` once every 5 minutes. Please wait to send your next at.", ephemeral: true });
-		}
+		interaction.reply(`${interaction.options.getString("type") === "@everyone" ? "@everyone" : "@here"} ${interaction.options.getString("message")}`);
 	} else {
 		interaction.reply({ content: "You are not currently permitted to use `/at-channel`. Please speak to a moderator if you believe this to be in error.", ephemeral: true });
 	}

--- a/source/commands/at-channel.js
+++ b/source/commands/at-channel.js
@@ -13,7 +13,7 @@ module.exports = new Command("at-channel", "Send a ping to the current channel",
  */
 module.exports.execute = (interaction) => {
 	if (!noAts.includes(interaction.user.id)) {
-		interaction.reply(`${interaction.options.getString("type") === "@everyone" ? "@everyone" : "@here"} ${interaction.options.getString("message")}`);
+		interaction.reply(`${interaction.options.getString("type")} ${interaction.options.getString("message")}`);
 	} else {
 		interaction.reply({ content: "You are not currently permitted to use `/at-channel`. Please speak to a moderator if you believe this to be in error.", ephemeral: true });
 	}

--- a/source/commands/at-event.js
+++ b/source/commands/at-event.js
@@ -1,0 +1,30 @@
+const Command = require('../classes/Command.js');
+
+const options = [
+	{ type: "String", name: "event-id", description: "The id of the event to make an announcement for", required: true, choices: [] },
+	{ type: "String", name: "message", description: "The text of the notification", required: true, choices: [] }
+];
+const subcomands = [];
+module.exports = new Command("at-event", "Send a ping to users interested in an event", false, "none", 300000, options, subcomands);
+
+/** Send a rate-limited ping to users interested in an event
+ * @param {import('discord.js').Interaction} interaction
+ */
+module.exports.execute = async (interaction) => {
+	const unparsedEventId = interaction.options.getString("event-id");
+	const eventId = parseInt(unparsedEventId);
+	if (!eventId) {
+		interaction.reply({ content: `Could not parse **${unparsedEventId}** as an event id.`, ephemeral: true });
+		return;
+	}
+
+	const event = await interaction.guild.scheduledEvents.fetch(eventId);
+	if (!event) {
+		interaction.reply({ content: `Could not find an event with id: ${eventId}`, ephemeral: true });
+		return;
+	}
+
+	event.first().fetchSubscribers().then(subscribers => {
+		interaction.reply(`<@${subscribers.map((wrappedUser, userId) => userId).join(">, <@")}> ${interaction.options.getString("message")}`);
+	})
+}

--- a/source/commands/at-permission.js
+++ b/source/commands/at-permission.js
@@ -19,7 +19,7 @@ const subcomands = [
 		]
 	}
 ];
-module.exports = new Command("at-permission", "Disallow/Re-allow a user to use /at-channel", true, "moderator", options, subcomands);
+module.exports = new Command("at-permission", "Disallow/Re-allow a user to use /at-channel", true, "moderator", 3000, options, subcomands);
 
 module.exports.execute = (interaction) => {
 	const userId = interaction.options.getUser("user").id;

--- a/source/commands/club-add.js
+++ b/source/commands/club-add.js
@@ -7,7 +7,7 @@ const { modRoleId } = require('../engines/permissionEngine.js');
 
 const options = [{ type: "User", name: "club-host", description: "The user's mention", required: true, choices: [] }]
 const subcommands = [];
-module.exports = new Command("club-add", "Set up a club (a text and voice channel)", false, "moderator", options, subcommands);
+module.exports = new Command("club-add", "Set up a club (a text and voice channel)", false, "moderator", 3000, options, subcommands);
 
 /** Create a new club including a text and voice channel in the receiving channel's category and set the mentioned user as host
  * @param {import('discord.js').Interaction} interaction

--- a/source/commands/club-config.js
+++ b/source/commands/club-config.js
@@ -6,7 +6,7 @@ const { getClubDictionary } = require('../engines/referenceEngine.js');
 
 const options = [];
 const subcommands = [];
-module.exports = new Command("club-config", "Change the configuration of the current club", false, "moderator/club host", options, subcommands);
+module.exports = new Command("club-config", "Change the configuration of the current club", false, "moderator/club host", 3000, options, subcommands);
 
 /** Send the user an ephemeral message containing club configuration controls
  * @param {import('discord.js').Interaction} interaction

--- a/source/commands/club-invite.js
+++ b/source/commands/club-invite.js
@@ -10,7 +10,7 @@ const options = [
 	{ type: "User", name: "invitee", description: "The user's mention", required: false, choices: [] }
 ];
 const subcommands = [];
-module.exports = new Command("club-invite", "Send a user (default: self) an invite to a club", true, "none", options, subcommands);
+module.exports = new Command("club-invite", "Send a user (default: self) an invite to a club", true, "none", 3000, options, subcommands);
 
 /** Provide full details on the given club
  * @param {import('discord.js').Interaction} interaction

--- a/source/commands/club-kick.js
+++ b/source/commands/club-kick.js
@@ -8,7 +8,7 @@ const options = [
 	{ type: "Boolean", name: "ban", description: "Prevent the user from rejoining?", required: false, choices: [] }
 ];
 const subcomands = [];
-module.exports = new Command(id, "Remove a user from a club", false, "moderator/club host", options, subcomands);
+module.exports = new Command(id, "Remove a user from a club", false, "moderator/club host", 3000, options, subcomands);
 
 /** Remove visibility of receiving channel from mentioned user
  * @param {import('discord.js').Interaction} interaction

--- a/source/commands/club-leave.js
+++ b/source/commands/club-leave.js
@@ -6,7 +6,7 @@ const { getClubDictionary, updateClub, updateList } = require('../engines/refere
 const id = "club-leave";
 const options = [];
 const subcomands = [];
-module.exports = new Command(id, "Leave this club", false, "none", options, subcomands);
+module.exports = new Command(id, "Leave this club", false, "none", 3000, options, subcomands);
 
 /** Do cleanup associated with user leaving a club or topic
  * @param {import('discord.js').Interaction} interaction

--- a/source/commands/club-promote-host.js
+++ b/source/commands/club-promote-host.js
@@ -5,7 +5,7 @@ const { getClubDictionary, updateClub, updateList } = require('../engines/refere
 
 const options = [{ type: "User", name: "user", description: "The user's mention", required: true, choices: [] }];
 const subcommands = [];
-module.exports = new Command("club-update-host", "Promote another user to club host", false, "moderator/club host", options, subcommands);
+module.exports = new Command("club-update-host", "Promote another user to club host", false, "moderator/club host", 3000, options, subcommands);
 
 /** Update the club's host to the given user
  * @param {import('discord.js').Interaction} interaction

--- a/source/commands/club-send-reminder.js
+++ b/source/commands/club-send-reminder.js
@@ -4,7 +4,7 @@ const { getClubDictionary } = require('../engines/referenceEngine.js');
 
 const options = [];
 const subcommands = [];
-module.exports = new Command("club-send-reminder", "Re-post the reminder message for the club's next meeting", false, "moderator/club host", options, subcommands);
+module.exports = new Command("club-send-reminder", "Re-post the reminder message for the club's next meeting", false, "moderator/club host", 3000, options, subcommands);
 
 /** Re-post the reminder message for the club's next meeting
  * @param {import('discord.js').Interaction} interaction

--- a/source/commands/club-sunset.js
+++ b/source/commands/club-sunset.js
@@ -4,7 +4,7 @@ const { getClubDictionary } = require('../engines/referenceEngine.js');
 const id = "club-sunset";
 const options = [{ type: "Integer", name: "delay", description: "Number of hours to delay deleting the club", required: true, choices: [] }];
 const subcomands = [];
-module.exports = new Command(id, "Delete a club on a delay", false, "moderator/club host", options, subcomands);
+module.exports = new Command(id, "Delete a club on a delay", false, "moderator/club host", 3000, options, subcomands);
 
 /** Set a club to be deleted on a delay
  * @param {import('discord.js').Interaction} interaction

--- a/source/commands/commands.js
+++ b/source/commands/commands.js
@@ -14,7 +14,7 @@ const options = [
 	}
 ];
 const subcommands = [];
-module.exports = new Command("commands", "List HorizonsBot's commands", true, "none", options, subcommands);
+module.exports = new Command("commands", "List HorizonsBot's commands", true, "none", 3000, options, subcommands);
 
 let wikiPage;
 fs.readFile("wiki/Commands.md", { encoding: "utf-8" }, (error, data) => {

--- a/source/commands/info.js
+++ b/source/commands/info.js
@@ -32,7 +32,7 @@ const subcommands = [
 		optionsInput: []
 	}
 ];
-module.exports = new Command(customId, "Get info about the server or HorizonsBot", false, "none", options, subcommands);
+module.exports = new Command(customId, "Get info about the server or HorizonsBot", false, "none", 3000, options, subcommands);
 
 /** Get one of the informational messages for the user
  * @param {import('discord.js').Interaction} interaction

--- a/source/commands/list.js
+++ b/source/commands/list.js
@@ -6,7 +6,7 @@ const options = [
 	{ type: "String", name: "list-type", description: "The list to get", required: true, choices: [{ name: "Get the list of open topic petitions", value: "petition" }, { name: "Get the list of clubs on the server", value: "club" }] },
 ];
 const subcomands = [];
-module.exports = new Command(id, "Get the petition or club list", true, "none", options, subcomands);
+module.exports = new Command(id, "Get the petition or club list", true, "none", 3000, options, subcomands);
 
 /** Provide the user the petition or club list as requested
  * @param {import('discord.js').Interaction} interaction

--- a/source/commands/manage-mods.js
+++ b/source/commands/manage-mods.js
@@ -18,7 +18,7 @@ const subcomands = [
 		]
 	}
 ];
-module.exports = new Command("manage-mods", "Promote/demote a user to moderator", false, "moderator", options, subcomands);
+module.exports = new Command("manage-mods", "Promote/demote a user to moderator", false, "moderator", 3000, options, subcomands);
 
 /**
  * @param {import('discord.js').Interaction} interaction

--- a/source/commands/petition-check.js
+++ b/source/commands/petition-check.js
@@ -5,7 +5,7 @@ const options = [
 	{ type: "String", name: "topic", description: "The petition to check", required: true, choices: [] },
 ];
 const subcomands = [];
-module.exports = new Command("petition-check", "Check how many more petitions a topic needs", false, "none", options, subcomands);
+module.exports = new Command("petition-check", "Check how many more petitions a topic needs", false, "none", 3000, options, subcomands);
 
 /** Check if the given petition has enough support to make into a channel
  * @param {import('discord.js').Interaction} interaction

--- a/source/commands/petition-veto.js
+++ b/source/commands/petition-veto.js
@@ -5,7 +5,7 @@ const options = [
 	{ type: "String", name: "topic", description: "The petition to close", required: true, choices: [] },
 ];
 const subcomands = [];
-module.exports = new Command("petition-veto", "Veto a petition", true, "moderator", options, subcomands);
+module.exports = new Command("petition-veto", "Veto a petition", true, "moderator", 3000, options, subcomands);
 
 /** Remove the given petition from the petition list
  * @param {import('discord.js').Interaction} interaction

--- a/source/commands/petition.js
+++ b/source/commands/petition.js
@@ -5,7 +5,7 @@ const options = [
 	{ type: "String", name: "topic-name", description: "Make sure the topic doesn't already exist", required: true, choices: [] }
 ];
 const subcomands = [];
-module.exports = new Command("petition", "Petition for a topic text channel", false, "none", options, subcomands);
+module.exports = new Command("petition", "Petition for a topic text channel", false, "none", 3000, options, subcomands);
 
 /** Record a user's petition for a text channel, create channel if sufficient number of petitions
  * @param {import('discord.js').Interaction} interaction */

--- a/source/commands/post-reference.js
+++ b/source/commands/post-reference.js
@@ -16,7 +16,7 @@ const options = [
 	}
 ];
 const subcomands = [];
-module.exports = new Command(customId, "Post a reference message in this channel", false, "moderator", options, subcomands);
+module.exports = new Command(customId, "Post a reference message in this channel", false, "moderator", 3000, options, subcomands);
 
 /** Send a reference message (petitions, clubs, rules) to the receiving channel
  * @param {import('discord.js').Interaction} interaction

--- a/source/commands/roll.js
+++ b/source/commands/roll.js
@@ -15,7 +15,7 @@ const options = [
 	{ type: "String", name: "label", description: "Text after the roll", required: false, choices: [] },
 ];
 const subcomands = [];
-module.exports = new Command("roll", "Roll any number of dice with any number of sides", true, "none", options, subcomands);
+module.exports = new Command("roll", "Roll any number of dice with any number of sides", true, "none", 3000, options, subcomands);
 
 /** Roll the specified dice
  * @param {import('discord.js').Interaction} interaction

--- a/source/commands/timestamp.js
+++ b/source/commands/timestamp.js
@@ -8,7 +8,7 @@ const options = [
 	{ type: "Number", name: "minutes-from-start", description: "60 seconds", required: false, choices: [] }
 ];
 const subcomands = [];
-module.exports = new Command("timestamp", "Calculate the unix timestamp for a moment in time, which Discord displays with timezones applied", true, "none", options, subcomands);
+module.exports = new Command("timestamp", "Calculate the unix timestamp for a moment in time, which Discord displays with timezones applied", true, "none", 3000, options, subcomands);
 
 /** Calculate the unix timestamp given days, hours, minutes, and seconds from now (or the provided start)
  * @param {import('discord.js').Interaction} interaction

--- a/source/commands/topic-add.js
+++ b/source/commands/topic-add.js
@@ -5,7 +5,7 @@ const options = [
 	{ type: "String", name: "topic-name", description: "The new topic", required: true, choices: [] },
 ];
 const subcomands = [];
-module.exports = new Command("topic-add", "Set up a topic", false, "moderator", options, subcomands);
+module.exports = new Command("topic-add", "Set up a topic", false, "moderator", 3000, options, subcomands);
 
 /** Creates a new text channel and add it to list of topic channels (to prevent duplicate petitions)
  * @param {import('discord.js').Interaction} interaction

--- a/source/commands/version.js
+++ b/source/commands/version.js
@@ -5,7 +5,7 @@ const options = [
 	{ type: "Boolean", name: "full-notes", description: "Get the file with the full version notes?", required: true, choices: [] }
 ];
 const subcomands = [];
-module.exports = new Command("version", "Get HorizonsBot's version notes", true, "none", options, subcomands);
+module.exports = new Command("version", "Get HorizonsBot's version notes", true, "none", 3000, options, subcomands);
 
 /** Send version information
  * @param {import('discord.js').Interaction} interaction

--- a/source/modalSubmissions/_modalSubmissionDictionary.js
+++ b/source/modalSubmissions/_modalSubmissionDictionary.js
@@ -6,14 +6,12 @@ for (const file of [
 	"changeclubseats.js"
 ]) {
 	const modalSubmission = require(`./${file}`);
-	modalSubmissionDictionary[modalSubmission.name] = modalSubmission;
+	modalSubmissionDictionary[modalSubmission.customId] = modalSubmission;
 }
 
 /**
  * @param {string} mainId
- * @param {import("discord.js").Interaction} interaction
- * @param {string[]} args
  */
-exports.callModalSubmission = function (mainId, interaction, args) {
-	modalSubmissionDictionary[mainId].execute(interaction, args);
+exports.getModal = function (mainId) {
+	return modalSubmissionDictionary[mainId];
 }

--- a/source/modalSubmissions/changeclubinfo.js
+++ b/source/modalSubmissions/changeclubinfo.js
@@ -5,7 +5,7 @@ const { getClubDictionary, updateClub, updateList } = require('../engines/refere
 
 
 const id = "changeclubinfo";
-module.exports = new ModalSubmission(id,
+module.exports = new ModalSubmission(id, 3000,
 	/** Set the name, description, game, image and/or color for the club with provided id */
 	async (interaction, [clubId]) => {
 		const club = getClubDictionary()[clubId];

--- a/source/modalSubmissions/changeclubmeeting.js
+++ b/source/modalSubmissions/changeclubmeeting.js
@@ -6,7 +6,7 @@ const { getClubDictionary, updateClub, updateList } = require('../engines/refere
 const YEAR_IN_MS = 31556926000;
 
 const id = "changeclubmeeting";
-module.exports = new ModalSubmission(id,
+module.exports = new ModalSubmission(id, 3000,
 	/** Set the meeting time/repetition properties for the club with provided id */
 	async (interaction, [clubId]) => {
 		const club = getClubDictionary()[clubId];

--- a/source/modalSubmissions/changeclubseats.js
+++ b/source/modalSubmissions/changeclubseats.js
@@ -4,7 +4,7 @@ const { updateClubDetails } = require('../engines/clubEngine.js');
 const { getClubDictionary, updateClub, updateList } = require('../engines/referenceEngine.js');
 
 const id = "changeclubseats";
-module.exports = new ModalSubmission(id,
+module.exports = new ModalSubmission(id, 3000,
 	/** Set the max members and isRecruting for the club with provided id */
 	async (interaction, [clubId]) => {
 		const club = getClubDictionary()[clubId];

--- a/source/scripts/updateWiki.js
+++ b/source/scripts/updateWiki.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const { commandSets } = require('../commands/_commandDictionary.js');
 const Command = require('../classes/Command.js');
+const { SlashCommandSubcommandBuilder } = require('discord.js');
 
 require("./initialize.js");
 
@@ -13,7 +14,13 @@ commandSets.forEach(commandSet => {
 		const command = require(`./../commands/${filename}`);
 		text += `### /${command.customId}\n> Cooldown: ${command.cooldown / 1000} second(s)\n\n${command.description}\n`;
 		for (const optionData of command.data.options) {
-			text += `#### ${optionData.name}${!("required" in optionData) || optionData.required ? "" : " (optional)"}\n`;
+			let optionName = "#### ";
+			if (optionData instanceof SlashCommandSubcommandBuilder) {
+				optionName += `/${command.customId} ${optionData.name}\n`;
+			} else {
+				optionName += `${optionData.name}${optionData.required ? "" : " (optional)"}\n`;
+			}
+			text += optionName;
 			if (optionData.choices?.length > 0) {
 				text += `> Choices: \`${optionData.choices.map(choice => choice.name).join("`, `")}\`\n\n`;
 			}

--- a/source/scripts/updateWiki.js
+++ b/source/scripts/updateWiki.js
@@ -11,9 +11,13 @@ commandSets.forEach(commandSet => {
 	commandSet.fileNames.forEach(filename => {
 		/** @type {Command} */
 		const command = require(`./../commands/${filename}`);
-		text += `### /${command.customId}\n${command.description}\n`;
+		text += `### /${command.customId}\n> Cooldown: ${command.cooldown / 1000} second(s)\n\n${command.description}\n`;
 		for (const optionData of command.data.options) {
-			text += `#### ${optionData.name}${optionData.required ? "" : " (optional)"}\n${optionData.description}\n`;
+			text += `#### ${optionData.name}${optionData.required ? "" : " (optional)"}\n`;
+			if (optionData.choices?.length > 0) {
+				text += `> Choices: ${optionData.choices.map(choice => choice.name).join(", ")}\n`;
+			}
+			text += `\n${optionData.description}\n`;
 		}
 	})
 })

--- a/source/scripts/updateWiki.js
+++ b/source/scripts/updateWiki.js
@@ -11,7 +11,7 @@ commandSets.forEach(commandSet => {
 	commandSet.fileNames.forEach(filename => {
 		/** @type {Command} */
 		const command = require(`./../commands/${filename}`);
-		text += `### /${command.name}\n${command.description}\n`;
+		text += `### /${command.customId}\n${command.description}\n`;
 		for (const optionData of command.data.options) {
 			text += `#### ${optionData.name}${optionData.required ? "" : " (optional)"}\n${optionData.description}\n`;
 		}

--- a/source/scripts/updateWiki.js
+++ b/source/scripts/updateWiki.js
@@ -15,9 +15,9 @@ commandSets.forEach(commandSet => {
 		for (const optionData of command.data.options) {
 			text += `#### ${optionData.name}${optionData.required ? "" : " (optional)"}\n`;
 			if (optionData.choices?.length > 0) {
-				text += `> Choices: ${optionData.choices.map(choice => choice.name).join(", ")}\n`;
+				text += `> Choices: ${optionData.choices.map(choice => choice.name).join(", ")}\n\n`;
 			}
-			text += `\n${optionData.description}\n`;
+			text += `${optionData.description}\n`;
 		}
 	})
 })

--- a/source/scripts/updateWiki.js
+++ b/source/scripts/updateWiki.js
@@ -13,9 +13,9 @@ commandSets.forEach(commandSet => {
 		const command = require(`./../commands/${filename}`);
 		text += `### /${command.customId}\n> Cooldown: ${command.cooldown / 1000} second(s)\n\n${command.description}\n`;
 		for (const optionData of command.data.options) {
-			text += `#### ${optionData.name}${optionData.required ? "" : " (optional)"}\n`;
+			text += `#### ${optionData.name}${!("required" in optionData) || optionData.required ? "" : " (optional)"}\n`;
 			if (optionData.choices?.length > 0) {
-				text += `> Choices: ${optionData.choices.map(choice => choice.name).join(", ")}\n\n`;
+				text += `> Choices: \`${optionData.choices.map(choice => choice.name).join("`, `")}\`\n\n`;
 			}
 			text += `${optionData.description}\n`;
 		}

--- a/source/selects/_selectDictionary.js
+++ b/source/selects/_selectDictionary.js
@@ -5,14 +5,12 @@ for (const file of [
 	"petitionList.js"
 ]) {
 	const select = require(`./${file}`);
-	selectDictionary[select.name] = select;
+	selectDictionary[select.customId] = select;
 }
 
 /**
  * @param {string} mainId
- * @param {import("discord.js").Interaction} interaction
- * @param {string[]} args
  */
-exports.callSelect = function (mainId, interaction, args) {
-	selectDictionary[mainId].execute(interaction, args);
+exports.getSelect = function (mainId) {
+	return selectDictionary[mainId];
 }

--- a/source/selects/clubList.js
+++ b/source/selects/clubList.js
@@ -4,7 +4,7 @@ const { getClubDictionary } = require('../engines/referenceEngine.js');
 const { clubEmbedBuilder } = require('../engines/messageEngine.js');
 const { SAFE_DELIMITER } = require('../constants.js');
 
-module.exports = new Select("clubList",
+module.exports = new Select("clubList", 3000,
 	/** Provide club details embed to the user for the selected clubs */
 	(interaction, args) => {
 		const clubs = getClubDictionary();

--- a/source/selects/petitionList.js
+++ b/source/selects/petitionList.js
@@ -1,7 +1,7 @@
 const Select = require('../classes/Select.js');
 const { checkPetition } = require('../engines/referenceEngine.js');
 
-module.exports = new Select("petitionList",
+module.exports = new Select("petitionList", 3000,
 	/** Have the user petition for the selected topics */
 	(interaction, args) => {
 		interaction.values.forEach(petition => {

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -54,15 +54,15 @@ Use these commands to learn more about this server or HorizonsBot.
 > Cooldown: 3 second(s)
 
 Get info about the server or HorizonsBot
-#### horizonsbot-credits
+#### /info horizonsbot-credits
 Get the HorizonsBot credits
-#### server-rules
+#### /info server-rules
 Get the server rules
-#### horizonsbot-data-policy
+#### /info horizonsbot-data-policy
 See what data HorizonsBot collects and what it does with it
-#### roles-rundown
+#### /info roles-rundown
 See what the roles on the server mean and how to get them
-#### press-kit
+#### /info press-kit
 Get info on Imaginary Horizons as a brand
 ### /commands
 > Cooldown: 3 second(s)
@@ -146,9 +146,9 @@ Commands for moderators. Required permissions are listed in (parenthesis) at the
 > Cooldown: 3 second(s)
 
 (moderator) Disallow/Re-allow a user to use /at-channel
-#### disallow
+#### /at-permission disallow
 (moderator) Prevent a user from using /at-channel
-#### allow
+#### /at-permission allow
 (moderator) Re-allow a user to use /at-channel
 ### /petition-veto
 > Cooldown: 3 second(s)
@@ -166,9 +166,9 @@ The new topic
 > Cooldown: 3 second(s)
 
 (moderator) Promote/demote a user to moderator
-#### promote
+#### /manage-mods promote
 (moderator) Add a user to the moderator list
-#### demote
+#### /manage-mods demote
 (moderator) Remove a user from the moderator list
 ### /post-reference
 > Cooldown: 3 second(s)

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -1,112 +1,200 @@
 ## General Commands
 These commands are general use utilities for the server.
 ### /at-channel
+> Cooldown: 300 second(s)
+
 Send a ping to the current channel
 #### message
+
 The text of the notification
 #### type (optional)
+> Choices: Only online users in this channel, All users in this channel
+
 Who to notify
 ### /timestamp
+> Cooldown: 3 second(s)
+
 Calculate the unix timestamp for a moment in time, which Discord displays with timezones applied
 #### start (optional)
+
 The timestamp to start from (default: now)
 #### days-from-start (optional)
+
 86400 seconds
 #### hours-from-start (optional)
+
 3600 seconds
 #### minutes-from-start (optional)
+
 60 seconds
 ### /roll
+> Cooldown: 3 second(s)
+
 Roll any number of dice with any number of sides
 #### dice
+
 The dice to roll in #d# format
 #### display (optional)
+> Choices: Result only, Compare to max total roll, Result for each die, Compare each die to max roll
+
 Choose output display option
 #### label (optional)
+
 Text after the roll
 ### /petition
+> Cooldown: 3 second(s)
+
 Petition for a topic text channel
 #### topic-name
+
 Make sure the topic doesn't already exist
 ## Informantional Commands
 Use these commands to learn more about this server or HorizonsBot.
-### /rules
+### /info
+> Cooldown: 3 second(s)
+
+Get info about the server or HorizonsBot
+#### horizonsbot-credits (optional)
+
+Get the HorizonsBot credits
+#### server-rules (optional)
+
 Get the server rules
+#### horizonsbot-data-policy (optional)
+
+See what data HorizonsBot collects and what it does with it
+#### roles-rundown (optional)
+
+See what the roles on the server mean and how to get them
+#### press-kit (optional)
+
+Get info on Imaginary Horizons as a brand
 ### /commands
+> Cooldown: 3 second(s)
+
 List HorizonsBot's commands
 #### page (optional)
+> Choices: General Commands, Informational Commands, Topic Commands, Club Commands, Moderation Commands
+
 Pick a single page of commands to view
-### /roles
-Get a rundown of the server's roles
 ### /list
+> Cooldown: 3 second(s)
+
 Get the petition or club list
 #### list-type
+> Choices: Get the list of open topic petitions, Get the list of clubs on the server
+
 The list to get
-### /about
-Get the HorizonsBot credits
 ### /version
+> Cooldown: 3 second(s)
+
 Get HorizonsBot's version notes
 #### full-notes
+
 Get the file with the full version notes?
-### /data-policy
-Show what user data HorizonsBot collects and how it's used
-### /press-kit
-Get info on Imaginary Horizons as a brand
+### /petition-check
+> Cooldown: 3 second(s)
+
+Check how many more petitions a topic needs
+#### topic
+
+The petition to check
 ## Club Commands
 Clubs are private text and voice channels that include organization utilities like automatic reminders.
 ### /club-invite
+> Cooldown: 3 second(s)
+
 Send a user (default: self) an invite to a club
 #### club-id (optional)
+
 The club text channel's id
 #### invitee (optional)
+
 The user's mention
 ### /club-kick
+> Cooldown: 3 second(s)
+
 Remove a user from a club
 #### target
+
 The user's mention
 #### ban (optional)
+
 Prevent the user from rejoining?
 ### /club-leave
+> Cooldown: 3 second(s)
+
 Leave this club
 ### /club-send-reminder
+> Cooldown: 3 second(s)
+
 Re-post the reminder message for the club's next meeting
 ### /club-config
+> Cooldown: 3 second(s)
+
 Change the configuration of the current club
 ### /club-update-host
+> Cooldown: 3 second(s)
+
 Promote another user to club host
 #### user
+
 The user's mention
 ### /club-add
+> Cooldown: 3 second(s)
+
 (moderator) Set up a club (a text and voice channel)
 #### club-host
+
 The user's mention
 ### /club-sunset
+> Cooldown: 3 second(s)
+
 Delete a club on a delay
 #### delay
+
 Number of hours to delay deleting the club
 ## Moderation Commands
 Commands for moderators. Required permissions are listed in (parenthesis) at the beginning of the description.
 ### /at-permission
+> Cooldown: 3 second(s)
+
 (moderator) Disallow/Re-allow a user to use /at-channel
 #### disallow (optional)
+
 (moderator) Prevent a user from using /at-channel
 #### allow (optional)
+
 (moderator) Re-allow a user to use /at-channel
-### /petition-check
-Check how many more petitions a topic needs
+### /petition-veto
+> Cooldown: 3 second(s)
+
+(moderator) Veto a petition
 #### topic
-The petition to check
+
+The petition to close
 ### /topic-add
+> Cooldown: 3 second(s)
+
 (moderator) Set up a topic
 #### topic-name
+
 The new topic
 ### /manage-mods
+> Cooldown: 3 second(s)
+
 (moderator) Promote/demote a user to moderator
 #### promote (optional)
+
 (moderator) Add a user to the moderator list
 #### demote (optional)
+
 (moderator) Remove a user from the moderator list
-### /pin-list
-(moderator) Pin the petition or club list message in this channel
-#### list-type
-The list to pin
+### /post-reference
+> Cooldown: 3 second(s)
+
+(moderator) Post a reference message in this channel
+#### reference
+> Choices: the petiton list, the club list, the rules embed, the press kit
+
+which message to post

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -7,7 +7,7 @@ Send a ping to the current channel
 #### message
 The text of the notification
 #### type (optional)
-> Choices: Only online users in this channel, All users in this channel
+> Choices: `Only online users in this channel`, `All users in this channel`
 
 Who to notify
 ### /timestamp
@@ -29,7 +29,7 @@ Roll any number of dice with any number of sides
 #### dice
 The dice to roll in #d# format
 #### display (optional)
-> Choices: Result only, Compare to max total roll, Result for each die, Compare each die to max roll
+> Choices: `Result only`, `Compare to max total roll`, `Result for each die`, `Compare each die to max roll`
 
 Choose output display option
 #### label (optional)
@@ -54,22 +54,22 @@ Use these commands to learn more about this server or HorizonsBot.
 > Cooldown: 3 second(s)
 
 Get info about the server or HorizonsBot
-#### horizonsbot-credits (optional)
+#### horizonsbot-credits
 Get the HorizonsBot credits
-#### server-rules (optional)
+#### server-rules
 Get the server rules
-#### horizonsbot-data-policy (optional)
+#### horizonsbot-data-policy
 See what data HorizonsBot collects and what it does with it
-#### roles-rundown (optional)
+#### roles-rundown
 See what the roles on the server mean and how to get them
-#### press-kit (optional)
+#### press-kit
 Get info on Imaginary Horizons as a brand
 ### /commands
 > Cooldown: 3 second(s)
 
 List HorizonsBot's commands
 #### page (optional)
-> Choices: General Commands, Informational Commands, Topic Commands, Club Commands, Moderation Commands
+> Choices: `General Commands`, `Informational Commands`, `Topic Commands`, `Club Commands`, `Moderation Commands`
 
 Pick a single page of commands to view
 ### /list
@@ -77,7 +77,7 @@ Pick a single page of commands to view
 
 Get the petition or club list
 #### list-type
-> Choices: Get the list of open topic petitions, Get the list of clubs on the server
+> Choices: `Get the list of open topic petitions`, `Get the list of clubs on the server`
 
 The list to get
 ### /version
@@ -146,9 +146,9 @@ Commands for moderators. Required permissions are listed in (parenthesis) at the
 > Cooldown: 3 second(s)
 
 (moderator) Disallow/Re-allow a user to use /at-channel
-#### disallow (optional)
+#### disallow
 (moderator) Prevent a user from using /at-channel
-#### allow (optional)
+#### allow
 (moderator) Re-allow a user to use /at-channel
 ### /petition-veto
 > Cooldown: 3 second(s)
@@ -166,15 +166,15 @@ The new topic
 > Cooldown: 3 second(s)
 
 (moderator) Promote/demote a user to moderator
-#### promote (optional)
+#### promote
 (moderator) Add a user to the moderator list
-#### demote (optional)
+#### demote
 (moderator) Remove a user from the moderator list
 ### /post-reference
 > Cooldown: 3 second(s)
 
 (moderator) Post a reference message in this channel
 #### reference
-> Choices: the petiton list, the club list, the rules embed, the press kit
+> Choices: `the petiton list`, `the club list`, `the rules embed`, `the press kit`
 
 which message to post

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -5,7 +5,6 @@ These commands are general use utilities for the server.
 
 Send a ping to the current channel
 #### message
-
 The text of the notification
 #### type (optional)
 > Choices: Only online users in this channel, All users in this channel
@@ -16,38 +15,39 @@ Who to notify
 
 Calculate the unix timestamp for a moment in time, which Discord displays with timezones applied
 #### start (optional)
-
 The timestamp to start from (default: now)
 #### days-from-start (optional)
-
 86400 seconds
 #### hours-from-start (optional)
-
 3600 seconds
 #### minutes-from-start (optional)
-
 60 seconds
 ### /roll
 > Cooldown: 3 second(s)
 
 Roll any number of dice with any number of sides
 #### dice
-
 The dice to roll in #d# format
 #### display (optional)
 > Choices: Result only, Compare to max total roll, Result for each die, Compare each die to max roll
 
 Choose output display option
 #### label (optional)
-
 Text after the roll
 ### /petition
 > Cooldown: 3 second(s)
 
 Petition for a topic text channel
 #### topic-name
-
 Make sure the topic doesn't already exist
+### /at-event
+> Cooldown: 300 second(s)
+
+Send a ping to users interested in an event
+#### event-id
+The id of the event to make an announcement for
+#### message
+The text of the notification
 ## Informantional Commands
 Use these commands to learn more about this server or HorizonsBot.
 ### /info
@@ -55,19 +55,14 @@ Use these commands to learn more about this server or HorizonsBot.
 
 Get info about the server or HorizonsBot
 #### horizonsbot-credits (optional)
-
 Get the HorizonsBot credits
 #### server-rules (optional)
-
 Get the server rules
 #### horizonsbot-data-policy (optional)
-
 See what data HorizonsBot collects and what it does with it
 #### roles-rundown (optional)
-
 See what the roles on the server mean and how to get them
 #### press-kit (optional)
-
 Get info on Imaginary Horizons as a brand
 ### /commands
 > Cooldown: 3 second(s)
@@ -90,14 +85,12 @@ The list to get
 
 Get HorizonsBot's version notes
 #### full-notes
-
 Get the file with the full version notes?
 ### /petition-check
 > Cooldown: 3 second(s)
 
 Check how many more petitions a topic needs
 #### topic
-
 The petition to check
 ## Club Commands
 Clubs are private text and voice channels that include organization utilities like automatic reminders.
@@ -106,20 +99,16 @@ Clubs are private text and voice channels that include organization utilities li
 
 Send a user (default: self) an invite to a club
 #### club-id (optional)
-
 The club text channel's id
 #### invitee (optional)
-
 The user's mention
 ### /club-kick
 > Cooldown: 3 second(s)
 
 Remove a user from a club
 #### target
-
 The user's mention
 #### ban (optional)
-
 Prevent the user from rejoining?
 ### /club-leave
 > Cooldown: 3 second(s)
@@ -138,21 +127,18 @@ Change the configuration of the current club
 
 Promote another user to club host
 #### user
-
 The user's mention
 ### /club-add
 > Cooldown: 3 second(s)
 
 (moderator) Set up a club (a text and voice channel)
 #### club-host
-
 The user's mention
 ### /club-sunset
 > Cooldown: 3 second(s)
 
 Delete a club on a delay
 #### delay
-
 Number of hours to delay deleting the club
 ## Moderation Commands
 Commands for moderators. Required permissions are listed in (parenthesis) at the beginning of the description.
@@ -161,34 +147,28 @@ Commands for moderators. Required permissions are listed in (parenthesis) at the
 
 (moderator) Disallow/Re-allow a user to use /at-channel
 #### disallow (optional)
-
 (moderator) Prevent a user from using /at-channel
 #### allow (optional)
-
 (moderator) Re-allow a user to use /at-channel
 ### /petition-veto
 > Cooldown: 3 second(s)
 
 (moderator) Veto a petition
 #### topic
-
 The petition to close
 ### /topic-add
 > Cooldown: 3 second(s)
 
 (moderator) Set up a topic
 #### topic-name
-
 The new topic
 ### /manage-mods
 > Cooldown: 3 second(s)
 
 (moderator) Promote/demote a user to moderator
 #### promote (optional)
-
 (moderator) Add a user to the moderator list
 #### demote (optional)
-
 (moderator) Remove a user from the moderator list
 ### /post-reference
 > Cooldown: 3 second(s)


### PR DESCRIPTION
Summary
-------
- added /at-event command
- added cooldown to all interactions
- added slash command cooldown and choices to wiki
- decided not to add /club-create-public-event:
   - voice channels cannot change type, meaning automated stage creation would require deleting the old voice channel then making a stage when the event began, then deleting the stage channel and making a voice channel when the event ends
   - there doesn't seem to be a way to set presenters for an event, which adds a lot of overhead to using stage channels
   - modals don't have date pickers and there aren't a lot of event properties that make sense to automate, meaning the UI for this command is not superior UX to the native discord event creation UI

Local Tests Performed
---------------------
- [x] bot still turns on
- [x] /at-event sends messages to users interested in the given event

Issue
-----
Closes #43