### PR TITLE
#53: inline joinChannel in join button (slash command was removed)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
           folder: '.'
 
       - name: Setup npm
-        run: npm ci
+        run: npm ci && node source/scripts/initialize.js
 
       - name: Update Commands
         run: node source/scripts/updateWiki.js

--- a/source/commands/club-add.js
+++ b/source/commands/club-add.js
@@ -18,7 +18,7 @@ module.exports.execute = (interaction) => {
 	let categoryId = interaction.channel.parentId;
 
 	channelManager.create({
-		name: "new-club-text",
+		name: "new-club",
 		parent: categoryId,
 		permissionOverwrites: [
 			{

--- a/source/commands/club-invite.js
+++ b/source/commands/club-invite.js
@@ -25,25 +25,19 @@ module.exports.execute = (interaction) => {
 
 	const recipient = interaction.options.getUser("invitee") || interaction.user;
 	if (!recipient.bot) {
-		if (recipient.id !== club.hostId && !club.userIds.includes(recipient.id)) {
-			recipient.send({
-				embeds: [clubEmbedBuilder(club)], components: [new ActionRowBuilder(
-					{
-						components: [
-							new ButtonBuilder({
-								custom_id: `join${SAFE_DELIMITER}${club.id}`,
-								label: `Join ${club.title}`,
-								style: ButtonStyle.Success
-							})
-						]
-					}
-				)]
-			}).then(() => {
-				interaction.reply({ content: "Club details have been sent.", ephemeral: true });
-			}).catch(console.error);
-		} else {
-			interaction.reply({ content: "If the club details are not pinned, the club host can have them reposted and pinned with `/club-details`.", ephemeral: true })
-				.catch(console.error);
-		}
+		const components = recipient.id !== club.hostId && !club.userIds.includes(recipient.id) ? [new ActionRowBuilder(
+			{
+				components: [
+					new ButtonBuilder({
+						custom_id: `join${SAFE_DELIMITER}${club.id}`,
+						label: `Join ${club.title}`,
+						style: ButtonStyle.Success
+					})
+				]
+			}
+		)] : [];
+		recipient.send({ embeds: [clubEmbedBuilder(club)], components }).then(() => {
+			interaction.reply({ content: "Club details have been sent.", ephemeral: true });
+		}).catch(console.error);
 	}
 }

--- a/source/scripts/updateWiki.js
+++ b/source/scripts/updateWiki.js
@@ -3,8 +3,6 @@ const { commandSets } = require('../commands/_commandDictionary.js');
 const Command = require('../classes/Command.js');
 const { SlashCommandSubcommandBuilder } = require('discord.js');
 
-require("./initialize.js");
-
 let text = "";
 
 commandSets.forEach(commandSet => {


### PR DESCRIPTION
Summary
-------
- inline joinChannel in join button (slash command was removed)
- ported script fixes from template
- matched default club text channel name with internal default
- /club-invite no longer has an error message referring to a removed command

Local Tests Performed
---------------------
- [x] bot still turns on
- [x] was able to join a club
- [x] was shown an error message if unable to join a club

Issue
-----
Closes #53