### PR TITLE
Fix roll system to not throw errors on valid input

### DIFF
--- a/source/engines/rollEngine.js
+++ b/source/engines/rollEngine.js
@@ -339,6 +339,7 @@ class SingleResultSet extends ResultSet {
 	 * @param {boolean} isRoll 
 	 */
 	constructor(value, isRoll = true) {
+		super();
 		if (isRoll) {
 			const valueArr = value.split('d');
 			let poppedVal = valueArr.pop();
@@ -405,6 +406,7 @@ class ListResultSet extends ResultSet {
 	 * @param {boolean} forceUnique 
 	 */
 	constructor(choices, list, forceUnique = false) {
+		super();
 		this.#result = []; // The options we have chosen
 		this.#choices = choices;
 		this.#forceUnique = forceUnique;
@@ -477,6 +479,7 @@ class TwoOpResultSet extends ResultSet {
 	 * @param {(two_ops.ADD|two_ops.SUBTRACT|two_ops.MULTIPLY)} op 
 	 */
 	constructor(left, right, op) {
+		super();
 		this.#left = ResultSet.parse(left);
 		this.#right = ResultSet.parse(right);
 		this.#op = op;
@@ -658,6 +661,7 @@ class MultiDieResultSet extends ResultSet {
 	 * @param {number} dieSides 
 	 */
 	constructor(numDice, dieSides) {
+		super();
 		let convertedDieSides = dieSides.replace('d', '');
 		convertedDieSides = convertedDieSides == '%' ? '100' : convertedDieSides;
 		this.#dieSides = parseInt(convertedDieSides);
@@ -722,6 +726,7 @@ class SumSeriesResultSet extends ResultSet {
 	 * @param {Array<string>} listToSum 
 	 */
 	constructor(listToSum) {
+		super();
 		for (let i = 0; i < listToSum.length; i += 1) {
 			if (listToSum[i][0] == '-') {
 				this.#opList.push(two_ops.SUBTRACT);
@@ -835,6 +840,7 @@ class DieSelectResultSet extends ResultSet {
 	 * @param {number} selectNum 
 	 */
 	constructor(numDice, dieSides, selectOp, selectNum) {
+		super();
 		let convertedDieSides = dieSides.replace('d', '');
 		convertedDieSides = convertedDieSides == '%' ? '100' : convertedDieSides;
 		this.#dieSides = parseInt(convertedDieSides);

--- a/source/engines/rollEngine.js
+++ b/source/engines/rollEngine.js
@@ -339,7 +339,6 @@ class SingleResultSet extends ResultSet {
 	 * @param {boolean} isRoll 
 	 */
 	constructor(value, isRoll = true) {
-		super();
 		if (isRoll) {
 			const valueArr = value.split('d');
 			let poppedVal = valueArr.pop();
@@ -406,7 +405,6 @@ class ListResultSet extends ResultSet {
 	 * @param {boolean} forceUnique 
 	 */
 	constructor(choices, list, forceUnique = false) {
-		super();
 		this.#result = []; // The options we have chosen
 		this.#choices = choices;
 		this.#forceUnique = forceUnique;
@@ -479,7 +477,6 @@ class TwoOpResultSet extends ResultSet {
 	 * @param {(two_ops.ADD|two_ops.SUBTRACT|two_ops.MULTIPLY)} op 
 	 */
 	constructor(left, right, op) {
-		super();
 		this.#left = ResultSet.parse(left);
 		this.#right = ResultSet.parse(right);
 		this.#op = op;
@@ -661,7 +658,6 @@ class MultiDieResultSet extends ResultSet {
 	 * @param {number} dieSides 
 	 */
 	constructor(numDice, dieSides) {
-		super();
 		let convertedDieSides = dieSides.replace('d', '');
 		convertedDieSides = convertedDieSides == '%' ? '100' : convertedDieSides;
 		this.#dieSides = parseInt(convertedDieSides);
@@ -726,7 +722,6 @@ class SumSeriesResultSet extends ResultSet {
 	 * @param {Array<string>} listToSum 
 	 */
 	constructor(listToSum) {
-		super();
 		for (let i = 0; i < listToSum.length; i += 1) {
 			if (listToSum[i][0] == '-') {
 				this.#opList.push(two_ops.SUBTRACT);
@@ -840,7 +835,6 @@ class DieSelectResultSet extends ResultSet {
 	 * @param {number} selectNum 
 	 */
 	constructor(numDice, dieSides, selectOp, selectNum) {
-		super();
 		let convertedDieSides = dieSides.replace('d', '');
 		convertedDieSides = convertedDieSides == '%' ? '100' : convertedDieSides;
 		this.#dieSides = parseInt(convertedDieSides);

--- a/source/engines/rollEngine.js
+++ b/source/engines/rollEngine.js
@@ -126,7 +126,7 @@ class ResultSet {
 	/**
 	 * Creates an empty ResultSet. Invalid and requires calling a child class to construct.
 	 */
-	constructor() { throw new Error(`ResultSet cannot be constructed directly, or child class ${this.constructor.name} did not properly implement a constructor.`); }
+	constructor() { if (this.constructor.name === "ResultSet") throw new Error(`ResultSet cannot be constructed directly, or child class ${this.constructor.name} did not properly implement a constructor.`); }
 
 	/**
 	 * Checks to see if a string is surrounded by a parentheses set. Confirms that


### PR DESCRIPTION
Fixes #172

Summary
-------
After tracing the error, it seems like it is exclusively happening because someone (me) added `super()` calls to the root interface ResultSet class, which should never have its constructor called. Oops.

Local Tests Performed
---------------------
Gonna be honest, I didn't test this one yet, but the issue and solution are incredibly easy to trace here. Probably not the best habit to skip this step, but getting the solution committed faster so we can get this feature back feels like the right move here.

Issue
-----
Closes #172
