### PR TITLE
#180: use Components V2 to improve petitions embed

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 #### HorizonsBot Version 2.9.0:
 - Fixed `/roll` mistaking proper input for invalid input
 - Added "Clear Next Meeting Info" button to `/club-config`
+- Fixed petitions requiring 1 more signature than stated to be fulfilled
 
 #### HorizonsBot Version 2.8.0:
 - `/club-invite` now sends a message with a channel select menu and a user select menu instead of making users copy/paste the club's text channel id

--- a/source/commands/list/petitions.js
+++ b/source/commands/list/petitions.js
@@ -1,4 +1,4 @@
-const { CommandInteraction } = require("discord.js");
+const { CommandInteraction, MessageFlags } = require("discord.js");
 const { buildPetitionListPayload } = require("../../engines/referenceEngine");
 
 /**
@@ -6,10 +6,9 @@ const { buildPetitionListPayload } = require("../../engines/referenceEngine");
  * @param {...unknown} args
  */
 async function executeSubcommand(interaction, ...args) {
-	buildPetitionListPayload(interaction.guild.memberCount).then(messageOptions => {
-		messageOptions.ephemeral = true;
-		interaction.reply(messageOptions);
-	}).catch(console.error);
+	const messageOptions = await buildPetitionListPayload(interaction.guild.memberCount);
+	messageOptions.flags |= MessageFlags.Ephemeral;
+	interaction.reply(messageOptions);
 };
 
 module.exports = {

--- a/source/engines/customizationEngine.js
+++ b/source/engines/customizationEngine.js
@@ -63,7 +63,7 @@ async function checkChannelPetition(guild, channelName, author = null) {
 	const returnStats = {
 		name: channelName,
 		petitionCount: petition.petitionerIds.length,
-		threshold: Math.ceil(guild.memberCount * 0.05) + 1,
+		threshold: Math.ceil(guild.memberCount * 0.05),
 		result: "checkOnly"
 	};
 	if (author) {
@@ -173,7 +173,7 @@ function checkRolePetition(guild, roleName, author = null) {
 	const returnStats = {
 		name: roleName,
 		petitionCount: petition.petitionerIds.length,
-		threshold: Math.ceil(guild.memberCount * 0.05) + 1,
+		threshold: Math.ceil(guild.memberCount * 0.05),
 		result: "checkOnly"
 	};
 	if (author) {

--- a/source/engines/messageEngine.js
+++ b/source/engines/messageEngine.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
-const { EmbedBuilder, Colors } = require("discord.js");
-const { imaginaryHorizonsIconURL, discordIconURL } = require('../constants');
+const { EmbedBuilder, Colors, UserSelectMenuBuilder, ActionRowBuilder } = require("discord.js");
+const { imaginaryHorizonsIconURL, discordIconURL, SKIP_INTERACTION_HANDLING } = require('../constants');
 const { Club } = require('../classes');
 const { commandMention } = require('../util/textUtil');
 const { EmbedLimits } = require('@sapphire/discord.js-utilities');
@@ -177,11 +177,21 @@ function pressKitEmbedBuilder() {
 	})
 }
 
+/** @param {string} placeholderText */
+function disabledSelectRow(placeholderText) {
+	return new ActionRowBuilder().addComponents(
+		new UserSelectMenuBuilder().setCustomId(SKIP_INTERACTION_HANDLING)
+			.setPlaceholder(placeholderText)
+			.setDisabled(true)
+	)
+}
+
 module.exports = {
 	embedTemplateBuilder,
 	randomEmbedFooter,
 	clubEmbedBuilder,
 	versionEmbedBuilder,
 	rulesEmbedBuilder,
-	pressKitEmbedBuilder
+	pressKitEmbedBuilder,
+	disabledSelectRow
 };

--- a/source/engines/referenceEngine.js
+++ b/source/engines/referenceEngine.js
@@ -57,7 +57,7 @@ function buildPetitionListPayload(memberCount) {
 		const channelSelect = new StringSelectMenuBuilder().setCustomId("petitionChannel")
 			.setPlaceholder("Select a channel petition...")
 			.setMinValues(1)
-			.setMaxValues(channelSelect.options.length);
+			.setMaxValues(channelPetitions.length);
 		const channelOptions = [];
 		for (const petition of channelPetitions) {
 			channelOptions.push({
@@ -66,7 +66,7 @@ function buildPetitionListPayload(memberCount) {
 				value: petition.name
 			});
 		}
-		container.addActionRowComponents(new ActionRowBuilder().addComponents(channelSelect.slice(0, SelectMenuLimits.MaximumOptionsLength)))
+		container.addActionRowComponents(new ActionRowBuilder().addComponents(channelSelect.addOptions(channelOptions.slice(0, SelectMenuLimits.MaximumOptionsLength))))
 	} else {
 		container.addActionRowComponents(disabledSelectRow("No open channel petitions"))
 	}


### PR DESCRIPTION
Summary
-------
- use Components V2 to improve petitions embed

Migration Steps
--------
1. Clear `messageId` and `channelId` from `petition`'s value in `referenceMessageIds.json`
2. Remake Petition Reference Channel
3. Delete old Petition Reference Channel

Local Tests Performed
---------------------
- [x] bot still turns on
- [x] new copy-editing is free of typos and awkward sentences
- [x] selects disable if no open petitions
- [x] no regressions in selects

Issue
-----
Closes #180