### PR TITLE
#186: allow keeping club text channels as archives after sunsetting club

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 - Fixed `/roll` mistaking proper input for invalid input
 - Added "Clear Next Meeting Info" button to `/club-config`
 - Fixed petitions requiring 1 more signature than stated to be fulfilled
+- Clubs can now be archived without deleting thier text channel
 
 #### HorizonsBot Version 2.8.0:
 - `/club-invite` now sends a message with a channel select menu and a user select menu instead of making users copy/paste the club's text channel id

--- a/source/bot.js
+++ b/source/bot.js
@@ -18,7 +18,7 @@ const { getCommand, slashData } = require("./commands/_commandDictionary.js");
 const { getContextMenu, contextMenuData } = require("./context_menus/_contextMenuDictionary.js");
 const { getButton } = require("./buttons/_buttonDictionary.js");
 const { getSelect } = require("./selects/_selectDictionary.js");
-const { scheduleClubReminderAndEvent, updateClubDetails } = require("./engines/clubEngine.js");
+const { scheduleClubReminderAndEvent, updateClubDetails, clearClubReminder, cancelClubEvent } = require("./engines/clubEngine.js");
 const { deletePingableRole, updateOnboarding, removeAllPetitionsBy, checkAllPetitions, isOptInChannel, deleteOptInChannel } = require("./engines/customizationEngine.js");
 const { versionEmbedBuilder, rulesEmbedBuilder, pressKitEmbedBuilder } = require("./engines/messageEngine.js");
 const { referenceMessages, getClubDictionary, removeClub, updateListReference } = require("./engines/referenceEngine.js");
@@ -224,6 +224,8 @@ client.on(Events.ChannelDelete, ({ id, guild }) => {
 		const clubDictionary = getClubDictionary();
 		// Check if deleted channel is a club's text channel
 		if (id in clubDictionary) {
+			clearClubReminder(clubDictionary[id]);
+			cancelClubEvent(clubDictionary[id], guild.scheduledEvents);
 			const voiceChannel = guild.channels.resolve(clubDictionary[id].voiceChannelId);
 			if (voiceChannel) {
 				voiceChannel.delete();
@@ -235,6 +237,8 @@ client.on(Events.ChannelDelete, ({ id, guild }) => {
 		// Check if deleted channel is a club's voice channel
 		for (const club of Object.values(clubDictionary)) {
 			if (club.voiceChannelId === id) {
+				clearClubReminder(club);
+				cancelClubEvent(club, guild.scheduledEvents);
 				const textChannel = guild.channels.resolve(club.id);
 				if (textChannel) {
 					textChannel.send({ content: "This club has been archived because its voice channel was deleted." });

--- a/source/bot.js
+++ b/source/bot.js
@@ -237,7 +237,7 @@ client.on(Events.ChannelDelete, ({ id, guild }) => {
 			if (club.voiceChannelId === id) {
 				const textChannel = guild.channels.resolve(club.id);
 				if (textChannel) {
-					textChannel.delete();
+					textChannel.send({ content: "This club has been archived because its voice channel was deleted." });
 					removeClub(club.id, guild.channels);
 				}
 				return;

--- a/source/commands/club-sunset.js
+++ b/source/commands/club-sunset.js
@@ -18,6 +18,8 @@ module.exports = new CommandWrapper(mainId, "Remove a club's voice channel and r
 			if (delay > 0) {
 				interaction.reply(`This club has been scheduled to be archived in ${delay} hour(s).`)
 					.catch(console.error);
+				cancelClubEvent(club, interaction.guild.scheduledEvents);
+				clearClubReminder(club.id);
 				setTimeout(() => {
 					const voiceChannel = guild.channels.resolve(club.voiceChannelId);
 					if (voiceChannel) {

--- a/source/commands/club-sunset.js
+++ b/source/commands/club-sunset.js
@@ -2,6 +2,7 @@ const { CommandWrapper } = require('../classes/InteractionWrapper.js');
 const { getClubDictionary } = require('../engines/referenceEngine.js');
 const { isClubHostOrModerator } = require('../engines/permissionEngine.js');
 const { InteractionContextType, MessageFlags } = require('discord.js');
+const { cancelClubEvent, clearClubReminder } = require('../engines/clubEngine.js');
 
 const mainId = "club-sunset";
 module.exports = new CommandWrapper(mainId, "Remove a club's voice channel and remove it from the club dictionary on a delay", null, [InteractionContextType.Guild], 3000,


### PR DESCRIPTION
Summary
-------
- `/club sunset` and deleting a club's voice channel "archive" the club, removing it from the club dictionary, but leaving the text channel intact

Local Tests Performed
---------------------
- [x] bot still turns on
- [x] deleting a club's voice channel archives the club without deleting the text channel

Issue
-----
Closes #186 