### PR TITLE
#197: ignore interaction collector errors and handle can't dm this user errors

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,7 @@
 # HorizonsBot Change Log
+#### HorizonsBot Version 2.10.0:
+- Fixed several crashes related to the bot trying to send DMs to users who've blocked it
+
 #### HorizonsBot Version 2.9.0:
 - Fixed `/roll` mistaking proper input for invalid input
 - Added "Clear Next Meeting Info" button to `/club-config`

--- a/source/buttons/changeclubinfo.js
+++ b/source/buttons/changeclubinfo.js
@@ -6,6 +6,7 @@ const { updateClubDetails } = require('../engines/clubEngine.js');
 const { clubEmbedBuilder } = require('../engines/messageEngine.js');
 const { SAFE_DELIMITER, SKIP_INTERACTION_HANDLING } = require('../constants.js');
 const { ChannelLimits, ButtonLimits } = require('@sapphire/discord.js-utilities');
+const { butIgnoreDiscordInteractionCollectorErrors } = require('../util/dAPIResponses.js');
 
 const mainId = "changeclubinfo";
 module.exports = new ButtonWrapper(mainId, 3000,
@@ -112,6 +113,6 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				payload.content = "";
 			}
 			modalSubmission.update(payload);
-		}).catch(console.error);
+		}).catch(butIgnoreDiscordInteractionCollectorErrors);
 	}
 );

--- a/source/buttons/changeclubmeeting.js
+++ b/source/buttons/changeclubmeeting.js
@@ -5,6 +5,7 @@ const { updateClubDetails, cancelClubEvent, createClubEvent, scheduleClubReminde
 const { clubEmbedBuilder } = require('../engines/messageEngine.js');
 const { timeConversion } = require('../util/mathUtil.js');
 const { SKIP_INTERACTION_HANDLING, SAFE_DELIMITER } = require('../constants.js');
+const { butIgnoreDiscordInteractionCollectorErrors } = require('../util/dAPIResponses.js');
 
 const YEAR_IN_MS = 31556926000;
 
@@ -117,6 +118,6 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				payload.content = "";
 			}
 			modalSubmission.update(payload);
-		}).catch(console.error);
+		}).catch(butIgnoreDiscordInteractionCollectorErrors);
 	}
 );

--- a/source/buttons/changeclubseats.js
+++ b/source/buttons/changeclubseats.js
@@ -5,6 +5,7 @@ const { clubEmbedBuilder } = require('../engines/messageEngine.js');
 const { updateClubDetails } = require('../engines/clubEngine.js');
 const { timeConversion } = require('../util/mathUtil.js');
 const { SKIP_INTERACTION_HANDLING, SAFE_DELIMITER } = require('../constants.js');
+const { butIgnoreDiscordInteractionCollectorErrors } = require('../util/dAPIResponses.js');
 
 const mainId = "changeclubseats";
 module.exports = new ButtonWrapper(mainId, 3000,
@@ -54,6 +55,6 @@ module.exports = new ButtonWrapper(mainId, 3000,
 				payload.content = "";
 			}
 			modalSubmission.update(payload);
-		}).catch(console.error);
+		}).catch(butIgnoreDiscordInteractionCollectorErrors);
 	}
 );

--- a/source/buttons/proxyrename.js
+++ b/source/buttons/proxyrename.js
@@ -2,6 +2,7 @@ const { ButtonWrapper } = require('../classes');
 const { TextInputStyle, ModalBuilder, TextInputBuilder, LabelBuilder, bold } = require('discord.js');
 const { timeConversion } = require('../util/mathUtil');
 const { SKIP_INTERACTION_HANDLING, SAFE_DELIMITER } = require('../constants');
+const { butIgnoreDiscordInteractionCollectorErrors } = require('../util/dAPIResponses');
 
 const mainId = "proxyrename";
 module.exports = new ButtonWrapper(mainId, 3000,
@@ -23,6 +24,6 @@ module.exports = new ButtonWrapper(mainId, 3000,
 			const newName = modalSubmission.fields.fields.get("title").value;
 			interaction.channel.setName(newName);
 			modalSubmission.reply(`${interaction.member} renamed this thread to ${bold(newName)}.`);
-		})
+		}).catch(butIgnoreDiscordInteractionCollectorErrors)
 	}
 );

--- a/source/util/dAPIResponses.js
+++ b/source/util/dAPIResponses.js
@@ -1,0 +1,26 @@
+const { DiscordjsErrorCodes } = require("discord.js");
+
+// Discord API Opcodes and Status Codes: https://discord.com/developers/docs/topics/opcodes-and-status-codes
+
+/** @param {((error) => boolean)[]} ignoreThese */
+function butIgnoreCertainErrors(...ignoreThese) {
+	return (error) => {
+		for (const ignoreThis of ignoreThese) {
+			if (ignoreThis(error)) {
+				return;
+			}
+		}
+		console.error(error);
+	}
+}
+
+/** Interaction collectors throw an error on timeout (which is a crash if uncaught) */
+const butIgnoreDiscordInteractionCollectorErrors = butIgnoreCertainErrors(error => error.code === DiscordjsErrorCodes.InteractionCollectorError);
+
+const isCantDirectMessageThisUserError = error => error.code === 50007;
+
+module.exports = {
+	butIgnoreCertainErrors,
+	butIgnoreDiscordInteractionCollectorErrors,
+	isCantDirectMessageThisUserError
+}


### PR DESCRIPTION
Summary
-------
- ignore interaction collector errors and handle can't dm this user errors

Local Tests Performed
---------------------
- [x] bot still turns on
- [x] tested on [BountyBot version of PR](https://github.com/Imaginary-Horizons-Productions/BountyBot/pull/558)

Issue
-----
Closes #197